### PR TITLE
Fix bugs in slack computation of qubo_general01

### DIFF
--- a/qubogen/qubo.py
+++ b/qubogen/qubo.py
@@ -128,9 +128,10 @@ def qubo_general01(cost, a, b, sign, penalty=10.):
         sign: 0 is equality, 1 is >=, -1 is <=
     """
     slack = - sign * b
-    slack[sign == 0] = 1.
-    slack[sign == 1] += a[sign == 1, :].sum()
-    slack = np.ceil(np.log2(slack)).astype(np.int)
+    slack[sign == 0] = 0
+    slack[sign == 1] += np.maximum(a[sign == 1, :], 0).sum(axis=1)
+    slack[sign == -1] -= np.minimum(a[sign == -1, :], 0).sum(axis=1)
+    slack = np.ceil(np.log2(np.maximum(slack, 0) + 1)).astype(np.int)
 
     ni = a.shape[0]
     for i, ns in enumerate(slack):

--- a/tests/test_qubo.py
+++ b/tests/test_qubo.py
@@ -107,6 +107,49 @@ def test_qubo_general01():
     assert is_contain(sample[:, :5], np.array([1, 0, 0, 1, 1]))
 
 
+def test_qubo_general01_slack_0():
+    # max. - x0 - x1 subject to x0 <= 0
+    c = np.array([-1, -1])
+    a = np.array([[1, 0]])
+    b = np.array([0])
+    s = np.array([-1])
+    q = qubo_general01(c, a, b, s)
+    sample, _ = qbsolv_from_ndarray(q)
+    assert is_contain(sample[:, :2], np.array([0, 0]))
+
+
+def test_qubo_general01_slack_1():
+    # max. - x0 - x1 subject to x0 <= 1
+    c = np.array([-1, -1])
+    a = np.array([[1, 0]])
+    b = np.array([1])
+    s = np.array([-1])
+    q = qubo_general01(c, a, b, s)
+    sample, _ = qbsolv_from_ndarray(q)
+    assert is_contain(sample[:, :2], np.array([0, 0]))
+
+
+def test_qubo_general01_slack_minus1():
+    # max. - x0 - x1 subject to x0 <= -1
+    c = np.array([-1, -1])
+    a = np.array([[1, 0]])
+    b = np.array([-1])
+    s = np.array([-1])
+    q = qubo_general01(c, a, b, s)
+    sample, _ = qbsolv_from_ndarray(q)
+
+
+def test_qubo_general01_negative_a():
+    # max. - x0 - x1 subject to -1 x0 >= 0
+    c = np.array([-1, -1])
+    a = np.array([[-1, 0]])
+    b = np.array([0])
+    s = np.array([1])
+    q = qubo_general01(c, a, b, s)
+    sample, _ = qbsolv_from_ndarray(q)
+    assert is_contain(sample[:, :2], np.array([0, 0]))
+
+
 def test_qubo_qap():
     flow = [[0, 5, 2],
             [5, 0, 3],


### PR DESCRIPTION
I noticed that `qubo_general01` raises `ValueError: negative dimensions are not allowed`  or returns incorrect results in several cases.